### PR TITLE
Fix typedef annotation warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.example.serial_communication'
     compileSdkVersion 31
 
     compileOptions {

--- a/android/src/main/java/android_serialport_api/port/SerialApiManager.java
+++ b/android/src/main/java/android_serialport_api/port/SerialApiManager.java
@@ -12,6 +12,8 @@ import android.util.Log;
 
 import androidx.annotation.StringDef;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -32,6 +34,7 @@ public class SerialApiManager {
     public static final String write = "write";
     public static final String append = "append";
 
+    @Retention(RetentionPolicy.SOURCE)
     @StringDef({port, read, write, append})
     public @interface Type {
     }


### PR DESCRIPTION
Fix: Warning android_serialport_api.port.SerialApiManager.Type: The typedef annotation should have @Retention(RetentionPolicy.SOURCE)